### PR TITLE
Potential fix for code scanning alert no. 1: Reflected cross-site scripting

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"html"
 	"html/template"
 	"io"
 	"math/big"
@@ -468,7 +469,7 @@ func handlePublicRequest(ctx context.Context, w http.ResponseWriter, r *http.Req
 	tun, err := mgr.GetWithTenant(tenant, agentID)
 	if err != nil {
 		w.WriteHeader(502)
-		_, _ = w.Write([]byte("no agent for " + tenant + "/" + agentID))
+		_, _ = w.Write([]byte("no agent for " + html.EscapeString(tenant) + "/" + html.EscapeString(agentID)))
 		return
 	}
 	body, _ := io.ReadAll(http.MaxBytesReader(w, r.Body, 10<<20))


### PR DESCRIPTION
Potential fix for [https://github.com/DragonSecurity/drill/security/code-scanning/1](https://github.com/DragonSecurity/drill/security/code-scanning/1)

To fix the problem, sanitize/escape user-controlled data before incorporating it into HTTP responses which might be interpreted as HTML. In the vulnerable line, the variables `tenant` and `agentID` are incorporated directly into the output string. The preferred solution in Go is to use `html.EscapeString` from the `html` package to ensure these values are HTML-escaped before inclusion. This edit should be performed only where the response incorporates unsanitized user input for error/output messages.

Specifically, in internal/server/server.go, line 471:
Change `w.Write([]byte("no agent for " + tenant + "/" + agentID))` so that both `tenant` and `agentID` are escaped using `html.EscapeString`.

If the `html` package is not already imported, add `import "html"` to the imports.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
