### PR TITLE
Potential fix for code scanning alert no. 1: Reflected cross-site scripting

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -609,7 +609,7 @@ func handlePublicRequest(ctx context.Context, w http.ResponseWriter, r *http.Req
 	tun, err := mgr.GetWithTenant(tenant, agentID)
 	if err != nil {
 		w.WriteHeader(502)
-		_, _ = w.Write([]byte("no agent for " + tenant + "/" + agentID))
+		_, _ = w.Write([]byte("no agent for " + html.EscapeString(tenant) + "/" + html.EscapeString(agentID)))
 		return
 	}
 	body, _ := io.ReadAll(http.MaxBytesReader(w, r.Body, 10<<20))


### PR DESCRIPTION
Potential fix for [https://github.com/DragonSecurity/drill/security/code-scanning/1](https://github.com/DragonSecurity/drill/security/code-scanning/1)

The issue must be fixed by properly encoding user-controlled data before inserting it into the HTTP response. For output directly sent to browsers, the safest mechanism is to use HTML escaping even for bare text, since browsers might interpret unescaped input. The best fix is to wrap both `tenant` and `agentID` (both derived from user input) in `html.EscapeString` right before concatenation and sending in the response.

Change line 612 in internal/server/server.go to:
```go
_, _ = w.Write([]byte("no agent for " + html.EscapeString(tenant) + "/" + html.EscapeString(agentID)))
```
This sanitizes both parameters, ensuring no executable code or HTML can be injected into the response.

To implement this, ensure `html` is imported (`"html"`), which is already present in the provided imports.

Only the error message line needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
